### PR TITLE
Upgrade Spring Boot to v2.1.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.6.RELEASE</version>
+		<version>2.1.0.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Spring Framework 5.0.x phased out in favor of 5.1 by early 2019. 