### PR TITLE
Upgrade to com.fasterxml.jackson.core:jackson-databind@2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,12 +29,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>com.fasterxml.jackson.core</groupId>
+		    <artifactId>jackson-databind</artifactId>
+		    <version>2.9.8</version>
+		</dependency>		
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Deserialization of Untrusted Data
Vulnerable module: com.fasterxml.jackson.core:jackson-databind
Introduced through:
org.springframework.boot:spring-boot-starter-websocket@2.1.1.RELEASE and
com.fasterxml.jackson.core:jackson-databind@2.9.7